### PR TITLE
Fix tar-fs vulnerability

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -222,7 +222,7 @@
         "progress": "2.0.3",
         "proxy-agent": "6.4.0",
         "semver": "7.6.0",
-        "tar-fs": "3.0.5",
+        "tar-fs": "3.0.8",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -4155,9 +4155,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
       "dev": true,
       "dependencies": {
         "pump": "^3.0.0",


### PR DESCRIPTION
tar-fs Vulnerable to Link Following and Path Traversal via Extracting a Crafted tar File: https://github.com/dogeorg/identity-ui/security/dependabot/11